### PR TITLE
feat: add MiniMax as first-class LLM provider with provider factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@
 
 - [vinext](https://github.com/cloudflare/vinext) (Vite + React Server Components) 应用框架
 - Cloudflare Workers 部署和运行环境
-- TTS 语音合成
-- OpenAI API 内容生成
+- 多 LLM 提供商支持（OpenAI、[MiniMax](https://www.minimax.io) 等 OpenAI 兼容 API）
+- TTS 语音合成（Edge TTS / MiniMax Cloud TTS / Murf.ai）
 - Tailwind CSS 样式处理
 - shadcn-ui 组件库
 
@@ -60,9 +60,16 @@ NEXT_STATIC_HOST=http://localhost:3000/static
 NODE_ENV=development
 HACKER_PODCAST_WORKER_URL=https://you-worker-url
 HACKER_PODCAST_R2_BUCKET_URL=https://your-bucket-url
+
+# 使用 OpenAI (默认)
 OPENAI_API_KEY=your_api_key
 OPENAI_BASE_URL=https://api.openai.com/v1
 OPENAI_MODEL=gpt-4.1
+
+# 或使用 MiniMax (设置 LLM_PROVIDER=minimax 即可自动配置 base URL 和默认模型)
+# LLM_PROVIDER=minimax
+# MINIMAX_API_KEY=your_minimax_api_key
+# OPENAI_MODEL=MiniMax-M2.7          # 可选，默认 MiniMax-M2.7
 
 ```
 
@@ -81,6 +88,18 @@ pnpm dev
 >
 > - 本地运行工作流时，Edge TTS 转换音频可能会卡住。建议直接注释该部分代码进行调试。
 > - 由于合并音频需要使用 Cloudflare 的浏览器端呈现，不支持本地开发，需要远程调试。可以使用 `pnpm tests` 进行测试。
+
+## LLM 提供商
+
+项目支持通过 `LLM_PROVIDER` 环境变量切换 LLM 提供商：
+
+| 提供商 | `LLM_PROVIDER` | 默认模型 | API Key 环境变量 |
+|--------|----------------|----------|-----------------|
+| OpenAI | `openai`（默认） | `gpt-4.1` | `OPENAI_API_KEY` |
+| [MiniMax](https://www.minimax.io) | `minimax` | `MiniMax-M2.7` | `MINIMAX_API_KEY` |
+| 其他 OpenAI 兼容 | 不设置 | 需指定 `OPENAI_MODEL` | `OPENAI_API_KEY` |
+
+设置 `LLM_PROVIDER=minimax` 后，base URL 和默认模型会自动配置，只需提供 `MINIMAX_API_KEY`。也可通过 `OPENAI_BASE_URL` 和 `OPENAI_MODEL` 手动覆盖。
 
 ## 部署
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "dev:worker": "wrangler dev --cwd worker --persist-to ../.wrangler/state",
     "deploy:worker": "wrangler deploy --cwd worker",
     "logs:worker": "wrangler tail --cwd worker",
+    "test": "vitest run",
+    "test:integration": "vitest run --testPathPattern=integration",
     "tests": "wrangler dev --cwd tests --remote",
     "cf-typegen": "wrangler types --env-interface CloudflareEnv cloudflare-env.d.ts"
   },
@@ -76,6 +78,7 @@
     "tailwindcss": "^4.1.18",
     "typescript": "^5.9.3",
     "vite": "^7",
+    "vitest": "^3.2.4",
     "wrangler": "^4.68.1"
   },
   "simple-git-hooks": {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    include: ['workflow/__tests__/**/*.test.ts'],
+    environment: 'node',
+  },
+  resolve: {
+    alias: {
+      '@/': new URL('./', import.meta.url).pathname,
+    },
+  },
+})

--- a/workflow/__tests__/llm.integration.test.ts
+++ b/workflow/__tests__/llm.integration.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import { createLLMClient, getDefaultModel, getThinkingModel } from '../llm'
+
+describe('minimax LLM integration', () => {
+  const apiKey = process.env.MINIMAX_API_KEY
+  const shouldRun = !!apiKey
+
+  it.skipIf(!shouldRun)('creates a working MiniMax LLM client', async () => {
+    const client = createLLMClient({
+      LLM_PROVIDER: 'minimax',
+      MINIMAX_API_KEY: apiKey,
+    })
+    const model = getDefaultModel({ LLM_PROVIDER: 'minimax' })
+    expect(model).toBe('MiniMax-M2.7')
+
+    const modelInstance = client(model)
+    expect(modelInstance).toBeDefined()
+    expect(modelInstance.modelId).toBe('MiniMax-M2.7')
+  })
+
+  it.skipIf(!shouldRun)('supports custom model override', () => {
+    const model = getDefaultModel({
+      LLM_PROVIDER: 'minimax',
+      OPENAI_MODEL: 'MiniMax-M2.5-highspeed',
+    })
+    expect(model).toBe('MiniMax-M2.5-highspeed')
+
+    const client = createLLMClient({
+      LLM_PROVIDER: 'minimax',
+      MINIMAX_API_KEY: apiKey,
+    })
+    const modelInstance = client(model)
+    expect(modelInstance.modelId).toBe('MiniMax-M2.5-highspeed')
+  })
+
+  it.skipIf(!shouldRun)('thinking model falls back correctly', () => {
+    const thinking = getThinkingModel({ LLM_PROVIDER: 'minimax' })
+    expect(thinking).toBe('MiniMax-M2.7')
+
+    const thinkingWithOverride = getThinkingModel({
+      LLM_PROVIDER: 'minimax',
+      OPENAI_THINKING_MODEL: 'MiniMax-M2.5',
+    })
+    expect(thinkingWithOverride).toBe('MiniMax-M2.5')
+  })
+})

--- a/workflow/__tests__/llm.test.ts
+++ b/workflow/__tests__/llm.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest'
+import { createLLMClient, getDefaultModel, getThinkingModel } from '../llm'
+
+describe('createLLMClient', () => {
+  it('creates OpenAI client by default', () => {
+    const client = createLLMClient({
+      OPENAI_BASE_URL: 'https://api.openai.com/v1',
+      OPENAI_API_KEY: 'sk-test',
+    })
+    expect(client).toBeDefined()
+    expect(typeof client).toBe('function')
+  })
+
+  it('creates MiniMax client when LLM_PROVIDER=minimax', () => {
+    const client = createLLMClient({
+      LLM_PROVIDER: 'minimax',
+      MINIMAX_API_KEY: 'minimax-test-key',
+    })
+    expect(client).toBeDefined()
+    expect(typeof client).toBe('function')
+  })
+
+  it('uses MINIMAX_API_KEY when provider is minimax', () => {
+    const client = createLLMClient({
+      LLM_PROVIDER: 'minimax',
+      MINIMAX_API_KEY: 'minimax-key',
+      OPENAI_API_KEY: 'openai-key',
+    })
+    expect(client).toBeDefined()
+  })
+
+  it('falls back to OPENAI_API_KEY when MINIMAX_API_KEY is not set', () => {
+    const client = createLLMClient({
+      LLM_PROVIDER: 'minimax',
+      OPENAI_API_KEY: 'openai-key',
+    })
+    expect(client).toBeDefined()
+  })
+
+  it('respects custom OPENAI_BASE_URL even with minimax provider', () => {
+    const client = createLLMClient({
+      LLM_PROVIDER: 'minimax',
+      OPENAI_BASE_URL: 'https://custom.proxy.io/v1',
+      MINIMAX_API_KEY: 'minimax-key',
+    })
+    expect(client).toBeDefined()
+  })
+})
+
+describe('getDefaultModel', () => {
+  it('returns gpt-4.1 by default', () => {
+    expect(getDefaultModel({})).toBe('gpt-4.1')
+  })
+
+  it('returns MiniMax-M2.7 for minimax provider', () => {
+    expect(getDefaultModel({ LLM_PROVIDER: 'minimax' })).toBe('MiniMax-M2.7')
+  })
+
+  it('respects explicit OPENAI_MODEL override', () => {
+    expect(getDefaultModel({
+      LLM_PROVIDER: 'minimax',
+      OPENAI_MODEL: 'MiniMax-M2.5-highspeed',
+    })).toBe('MiniMax-M2.5-highspeed')
+  })
+
+  it('respects OPENAI_MODEL for default provider', () => {
+    expect(getDefaultModel({
+      OPENAI_MODEL: 'gpt-4o',
+    })).toBe('gpt-4o')
+  })
+})
+
+describe('getThinkingModel', () => {
+  it('returns gpt-4.1 by default', () => {
+    expect(getThinkingModel({})).toBe('gpt-4.1')
+  })
+
+  it('returns MiniMax-M2.7 for minimax provider', () => {
+    expect(getThinkingModel({ LLM_PROVIDER: 'minimax' })).toBe('MiniMax-M2.7')
+  })
+
+  it('prefers OPENAI_THINKING_MODEL over OPENAI_MODEL', () => {
+    expect(getThinkingModel({
+      OPENAI_THINKING_MODEL: 'o1',
+      OPENAI_MODEL: 'gpt-4.1',
+    })).toBe('o1')
+  })
+
+  it('falls back to OPENAI_MODEL when OPENAI_THINKING_MODEL is not set', () => {
+    expect(getThinkingModel({
+      OPENAI_MODEL: 'gpt-4.1',
+    })).toBe('gpt-4.1')
+  })
+
+  it('falls back to provider default when no model env is set', () => {
+    expect(getThinkingModel({
+      LLM_PROVIDER: 'minimax',
+    })).toBe('MiniMax-M2.7')
+  })
+})

--- a/workflow/__tests__/tts.test.ts
+++ b/workflow/__tests__/tts.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it, vi } from 'vitest'
+
+// Mock external dependencies before importing
+vi.mock('@echristian/edge-tts', () => ({
+  synthesize: vi.fn().mockResolvedValue({ audio: new Blob(['audio'], { type: 'audio/mpeg' }) }),
+}))
+
+vi.mock('ofetch', () => ({
+  $fetch: vi.fn().mockResolvedValue({
+    data: { audio: '48656c6c6f' },
+    base_resp: { status_msg: 'success' },
+  }),
+}))
+
+describe('tts provider selection', () => {
+  it('defaults to edge TTS when no provider specified', async () => {
+    const { default: synthesize } = await import('../tts')
+    const env = {} as Record<string, string>
+    // Should not throw - edge TTS mock is set up
+    const result = await synthesize('test', '男', env as never)
+    expect(result).toBeDefined()
+  })
+
+  it('selects minimax when TTS_PROVIDER=minimax', async () => {
+    const { $fetch } = await import('ofetch')
+    const { default: synthesize } = await import('../tts')
+    const env = {
+      TTS_PROVIDER: 'minimax',
+      TTS_API_KEY: 'test-key',
+    } as Record<string, string>
+    const result = await synthesize('test', '男', env as never)
+    expect(result).toBeDefined()
+    expect($fetch).toHaveBeenCalled()
+  })
+
+  it('uses correct MiniMax API URL without GroupId when TTS_API_ID is not set', async () => {
+    const { $fetch } = await import('ofetch')
+    const { default: synthesize } = await import('../tts')
+    vi.mocked($fetch).mockClear()
+
+    const env = {
+      TTS_PROVIDER: 'minimax',
+      TTS_API_KEY: 'test-key',
+    } as Record<string, string>
+    await synthesize('test', '女', env as never)
+
+    const calledUrl = vi.mocked($fetch).mock.calls[0]?.[0] as string
+    expect(calledUrl).toBe('https://api.minimax.io/v1/t2a_v2')
+    expect(calledUrl).not.toContain('GroupId')
+  })
+
+  it('appends GroupId when TTS_API_ID is set', async () => {
+    const { $fetch } = await import('ofetch')
+    const { default: synthesize } = await import('../tts')
+    vi.mocked($fetch).mockClear()
+
+    const env = {
+      TTS_PROVIDER: 'minimax',
+      TTS_API_KEY: 'test-key',
+      TTS_API_ID: 'group-123',
+    } as Record<string, string>
+    await synthesize('test', '男', env as never)
+
+    const calledUrl = vi.mocked($fetch).mock.calls[0]?.[0] as string
+    expect(calledUrl).toBe('https://api.minimax.io/v1/t2a_v2?GroupId=group-123')
+  })
+
+  it('uses speech-2.8-hd as default TTS model', async () => {
+    const { $fetch } = await import('ofetch')
+    const { default: synthesize } = await import('../tts')
+    vi.mocked($fetch).mockClear()
+
+    const env = {
+      TTS_PROVIDER: 'minimax',
+      TTS_API_KEY: 'test-key',
+    } as Record<string, string>
+    await synthesize('test', '男', env as never)
+
+    const body = vi.mocked($fetch).mock.calls[0]?.[1]?.body as string
+    const parsed = JSON.parse(body)
+    expect(parsed.model).toBe('speech-2.8-hd')
+  })
+
+  it('selects correct voice by gender', async () => {
+    const { $fetch } = await import('ofetch')
+    const { default: synthesize } = await import('../tts')
+
+    vi.mocked($fetch).mockClear()
+    const env = {
+      TTS_PROVIDER: 'minimax',
+      TTS_API_KEY: 'test-key',
+    } as Record<string, string>
+
+    await synthesize('test', '男', env as never)
+    const maleBody = JSON.parse(vi.mocked($fetch).mock.calls[0]?.[1]?.body as string)
+    expect(maleBody.timber_weights[0].voice_id).toBe('Chinese (Mandarin)_Gentleman')
+
+    vi.mocked($fetch).mockClear()
+    await synthesize('test', '女', env as never)
+    const femaleBody = JSON.parse(vi.mocked($fetch).mock.calls[0]?.[1]?.body as string)
+    expect(femaleBody.timber_weights[0].voice_id).toBe('Chinese (Mandarin)_Gentle_Senior')
+  })
+
+  it('only includes format in audio_setting', async () => {
+    const { $fetch } = await import('ofetch')
+    const { default: synthesize } = await import('../tts')
+    vi.mocked($fetch).mockClear()
+
+    const env = {
+      TTS_PROVIDER: 'minimax',
+      TTS_API_KEY: 'test-key',
+    } as Record<string, string>
+    await synthesize('test', '男', env as never)
+
+    const body = JSON.parse(vi.mocked($fetch).mock.calls[0]?.[1]?.body as string)
+    expect(body.audio_setting).toEqual({ format: 'mp3' })
+    expect(body.audio_setting.sample_rate).toBeUndefined()
+    expect(body.audio_setting.bitrate).toBeUndefined()
+  })
+
+  it('respects custom TTS_API_URL', async () => {
+    const { $fetch } = await import('ofetch')
+    const { default: synthesize } = await import('../tts')
+    vi.mocked($fetch).mockClear()
+
+    const env = {
+      TTS_PROVIDER: 'minimax',
+      TTS_API_KEY: 'test-key',
+      TTS_API_URL: 'https://custom.tts.api/v1/t2a_v2',
+    } as Record<string, string>
+    await synthesize('test', '男', env as never)
+
+    const calledUrl = vi.mocked($fetch).mock.calls[0]?.[0] as string
+    expect(calledUrl).toBe('https://custom.tts.api/v1/t2a_v2')
+  })
+})

--- a/workflow/index.ts
+++ b/workflow/index.ts
@@ -1,8 +1,8 @@
 import type { WorkflowEvent, WorkflowStep, WorkflowStepConfig } from 'cloudflare:workers'
-import { createOpenAICompatible } from '@ai-sdk/openai-compatible'
 import { generateText } from 'ai'
 import { WorkflowEntrypoint } from 'cloudflare:workers'
 import { podcastTitle } from '@/config'
+import { createLLMClient, getDefaultModel, getThinkingModel } from './llm'
 import { introPrompt, summarizeBlogPrompt, summarizePodcastPrompt, summarizeStoryPrompt } from './prompt'
 import synthesize from './tts'
 import { concatAudioFiles, getHackerNewsStory, getHackerNewsTopStories } from './utils'
@@ -12,9 +12,11 @@ interface Params {
 }
 
 interface Env extends CloudflareEnv {
-  OPENAI_BASE_URL: string
-  OPENAI_API_KEY: string
-  OPENAI_MODEL: string
+  LLM_PROVIDER?: string
+  OPENAI_BASE_URL?: string
+  OPENAI_API_KEY?: string
+  MINIMAX_API_KEY?: string
+  OPENAI_MODEL?: string
   OPENAI_THINKING_MODEL?: string
   OPENAI_MAX_TOKENS?: string
   JINA_KEY?: string
@@ -42,13 +44,9 @@ export class HackerNewsWorkflow extends WorkflowEntrypoint<Env, Params> {
     const isDev = runEnv !== 'production'
     const breakTime = isDev ? '2 seconds' : '5 seconds'
     const today = event.payload?.today || new Date().toISOString().split('T')[0]
-    const openai = createOpenAICompatible({
-      name: 'openai',
-      baseURL: this.env.OPENAI_BASE_URL!,
-      headers: {
-        Authorization: `Bearer ${this.env.OPENAI_API_KEY!}`,
-      },
-    })
+    const llm = createLLMClient(this.env)
+    const model = getDefaultModel(this.env)
+    const thinkingModel = getThinkingModel(this.env)
     const maxTokens = Number.parseInt(this.env.OPENAI_MAX_TOKENS || '4096')
 
     const stories = await step.do(`get top stories ${today}`, retryConfig, async () => {
@@ -74,7 +72,7 @@ export class HackerNewsWorkflow extends WorkflowEntrypoint<Env, Params> {
 
       const text = await step.do(`summarize story ${story.id}: ${story.title}`, retryConfig, async () => {
         const { text, usage, finishReason } = await generateText({
-          model: openai(this.env.OPENAI_MODEL!),
+          model: llm(model),
           system: summarizeStoryPrompt,
           prompt: storyResponse,
         })
@@ -106,7 +104,7 @@ export class HackerNewsWorkflow extends WorkflowEntrypoint<Env, Params> {
 
     const podcastContent = await step.do('create podcast content', retryConfig, async () => {
       const { text, usage, finishReason } = await generateText({
-        model: openai(this.env.OPENAI_THINKING_MODEL || this.env.OPENAI_MODEL!),
+        model: llm(thinkingModel),
         system: summarizePodcastPrompt,
         prompt: allStories.join('\n\n---\n\n'),
         maxOutputTokens: maxTokens,
@@ -124,7 +122,7 @@ export class HackerNewsWorkflow extends WorkflowEntrypoint<Env, Params> {
 
     const blogContent = await step.do('create blog content', retryConfig, async () => {
       const { text, usage, finishReason } = await generateText({
-        model: openai(this.env.OPENAI_THINKING_MODEL || this.env.OPENAI_MODEL!),
+        model: llm(thinkingModel),
         system: summarizeBlogPrompt,
         prompt: `<stories>${JSON.stringify(stories)}</stories>\n\n---\n\n${allStories.join('\n\n---\n\n')}`,
         maxOutputTokens: maxTokens,
@@ -142,7 +140,7 @@ export class HackerNewsWorkflow extends WorkflowEntrypoint<Env, Params> {
 
     const introContent = await step.do('create intro content', retryConfig, async () => {
       const { text, usage, finishReason } = await generateText({
-        model: openai(this.env.OPENAI_MODEL!),
+        model: llm(model),
         system: introPrompt,
         prompt: podcastContent,
         maxRetries: 3,

--- a/workflow/llm.ts
+++ b/workflow/llm.ts
@@ -1,0 +1,49 @@
+import { createOpenAICompatible } from '@ai-sdk/openai-compatible'
+
+interface LLMEnv {
+  LLM_PROVIDER?: string
+  OPENAI_BASE_URL?: string
+  OPENAI_API_KEY?: string
+  MINIMAX_API_KEY?: string
+  OPENAI_MODEL?: string
+  OPENAI_THINKING_MODEL?: string
+}
+
+interface ProviderPreset {
+  baseURL: string
+  defaultModel: string
+}
+
+const providerPresets: Record<string, ProviderPreset> = {
+  minimax: {
+    baseURL: 'https://api.minimax.io/v1',
+    defaultModel: 'MiniMax-M2.7',
+  },
+}
+
+export function createLLMClient(env: LLMEnv) {
+  const provider = env.LLM_PROVIDER || 'openai'
+  const preset = providerPresets[provider]
+  const baseURL = env.OPENAI_BASE_URL || preset?.baseURL || 'https://api.openai.com/v1'
+  const apiKey = (provider === 'minimax' && env.MINIMAX_API_KEY) || env.OPENAI_API_KEY
+
+  return createOpenAICompatible({
+    name: provider,
+    baseURL,
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+    },
+  })
+}
+
+export function getDefaultModel(env: LLMEnv) {
+  const provider = env.LLM_PROVIDER || 'openai'
+  const preset = providerPresets[provider]
+  return env.OPENAI_MODEL || preset?.defaultModel || 'gpt-4.1'
+}
+
+export function getThinkingModel(env: LLMEnv) {
+  const provider = env.LLM_PROVIDER || 'openai'
+  const preset = providerPresets[provider]
+  return env.OPENAI_THINKING_MODEL || env.OPENAI_MODEL || preset?.defaultModel || 'gpt-4.1'
+}

--- a/workflow/tts.ts
+++ b/workflow/tts.ts
@@ -24,7 +24,9 @@ async function edgeTTS(text: string, gender: string, env: Env) {
 }
 
 async function minimaxTTS(text: string, gender: string, env: Env) {
-  const result = await $fetch<{ data: { audio: string }, base_resp: { status_msg: string } }>(`${env.TTS_API_URL || 'https://api.minimaxi.com/v1/t2a_v2'}?GroupId=${env.TTS_API_ID}`, {
+  const apiURL = env.TTS_API_URL || 'https://api.minimax.io/v1/t2a_v2'
+  const url = env.TTS_API_ID ? `${apiURL}?GroupId=${env.TTS_API_ID}` : apiURL
+  const result = await $fetch<{ data: { audio: string }, base_resp: { status_msg: string } }>(url, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -32,7 +34,7 @@ async function minimaxTTS(text: string, gender: string, env: Env) {
     },
     timeout: 30000,
     body: JSON.stringify({
-      model: env.TTS_MODEL || 'speech-2.6-hd',
+      model: env.TTS_MODEL || 'speech-2.8-hd',
       text,
       timber_weights: [
         {
@@ -48,8 +50,6 @@ async function minimaxTTS(text: string, gender: string, env: Env) {
         latex_read: false,
       },
       audio_setting: {
-        sample_rate: 32000,
-        bitrate: 128000,
         format: 'mp3',
       },
       language_boost: 'Chinese',


### PR DESCRIPTION
## Summary

- Add LLM provider factory (`workflow/llm.ts`) with MiniMax M2.7 preset, supporting `LLM_PROVIDER=minimax` env var for one-line provider switching
- Refactor `workflow/index.ts` to use the provider factory, keeping full backward compatibility with existing `OPENAI_*` env vars
- Fix MiniMax TTS: update API URL (`api.minimaxi.com` to `api.minimax.io`), upgrade default model (`speech-2.6-hd` to `speech-2.8-hd`), fix `GroupId` query param when `TTS_API_ID` is unset, remove unsupported `audio_setting` fields (`sample_rate`/`bitrate`)
- Add LLM provider documentation table and MiniMax configuration examples to README
- Add vitest with 25 unit + integration tests for LLM provider factory and TTS provider selection

## Changes

| File | Description |
|------|-------------|
| `workflow/llm.ts` | New LLM provider factory with `createLLMClient()`, `getDefaultModel()`, `getThinkingModel()` |
| `workflow/index.ts` | Refactored to use provider factory, added `LLM_PROVIDER` and `MINIMAX_API_KEY` env vars |
| `workflow/tts.ts` | Fixed MiniMax TTS API URL, model version, GroupId handling, audio_setting |
| `README.md` | Added LLM provider table and MiniMax configuration docs |
| `vitest.config.ts` | Vitest test configuration |
| `workflow/__tests__/*.test.ts` | 25 unit + integration tests |
| `package.json` | Added vitest devDependency and test scripts |

## Test plan

- [x] All 25 vitest tests pass
- [x] ESLint passes on all changed files
- [ ] Verify MiniMax LLM with `LLM_PROVIDER=minimax` and `MINIMAX_API_KEY`
- [ ] Verify MiniMax TTS with updated API URL
- [ ] Verify backward compatibility with existing `OPENAI_*` env vars
