### PR TITLE
feat: add OmniVoice TTS provider with Voice Cloning support

### DIFF
--- a/workflow/tts/index.ts
+++ b/workflow/tts/index.ts
@@ -6,6 +6,7 @@ import { edgeTTS } from './edge'
 import { mimoTTS } from './mimo'
 import { minimaxTTS } from './minimax'
 import { murfTTS } from './murf'
+import { omnivoiceTTS } from './omnivoice'
 import {
   unAlibabaCloudTTS,
   unElevenLabsTTS,
@@ -29,6 +30,8 @@ export function synthesize(text: string, gender: Gender, env: Env): Promise<Blob
       return mimoTTS(text, gender, env)
     case 'murf':
       return murfTTS(text, gender, env)
+    case 'omnivoice':
+      return omnivoiceTTS(text, gender, env)
     case 'alibaba':
     case 'aliyun':
       return unAlibabaCloudTTS(text, gender, env)

--- a/workflow/tts/omnivoice.ts
+++ b/workflow/tts/omnivoice.ts
@@ -1,0 +1,67 @@
+import type { Env } from '../context'
+import type { Gender } from './types'
+import { parseAudioSpeed } from './config'
+import { createAudioBlob } from './config'
+import { $fetch } from 'ofetch'
+
+/**
+ * OmniVoice TTS provider.
+ *
+ * Calls a self-hosted OmniVoice instance via its Gradio API.
+ * The model is a Gradio app, so the interface uses `_design_fn`
+ * to submit synthesis parameters and returns a file path to fetch.
+ *
+ * Voice Cloning mode is supported via TTS_API_ID (reference audio URL).
+ */
+export async function omnivoiceTTS(text: string, gender: Gender, env: Env): Promise<Blob> {
+  const baseURL = env.TTS_API_URL || 'http://localhost:7860'
+  const speed = parseAudioSpeed(env.AUDIO_SPEED) ?? 1.0
+  const steps = Number(env.TTS_MODEL) || 32
+  const cloneAudioUrl = env.TTS_API_ID || null
+
+  const genderParam = gender === '男' ? 'Male / 男' : 'Female / 女'
+  const ageParam = 'Young Adult / 青年'
+  const pitchParam = gender === '男' ? 'Low Pitch / 低音调' : 'High Pitch / 高音调'
+  const accentParam = 'Chinese Accent / 中国口音'
+  const endpoint = `${baseURL}/gradio_api/api/_design_fn`
+
+  const payload = {
+    data: [
+      text,
+      'Chinese',
+      steps,
+      2.0,
+      true,
+      speed,
+      cloneAudioUrl,
+      true,
+      true,
+      genderParam,
+      ageParam,
+      pitchParam,
+      'Auto',
+      accentParam,
+      'Auto',
+    ],
+  }
+
+  const result = await $fetch<{ data: [{ path: string }] }>(endpoint, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    timeout: 60000,
+    body: payload,
+  })
+
+  const path = result?.data?.[0]?.path
+  if (!path) {
+    throw new Error(`OmniVoice TTS failed: ${JSON.stringify(result)}`)
+  }
+
+  const audioBuffer = await $fetch<ArrayBuffer>(`${baseURL}/gradio_api/file=${path}`, {
+    responseType: 'arrayBuffer',
+  })
+
+  return createAudioBlob(audioBuffer)
+}


### PR DESCRIPTION
## OmniVoice TTS Provider

Adds support for [OmniVoice](https://github.com/lenML/OmniVoice) as a TTS provider. OmniVoice is a self-hosted zero-shot voice cloning TTS engine exposed via Gradio API.

### Features

- **Gender-based voice selection** — Male/Female parameters with pitch/age control
- **Voice Cloning** — Optional reference audio URL via `TTS_API_ID` for zero-shot voice cloning
- **Configurable diffusion steps** — `TTS_MODEL` controls steps (default 32)
- **Speed control** — `AUDIO_SPEED` adjusts speech rate

### Usage

```env
TTS_PROVIDER=omnivoice
TTS_API_URL=http://your-gradio-host:7860
TTS_MODEL=32                    # diffusion steps
AUDIO_SPEED=1.0                 # speech speed
TTS_API_ID=https://example.com/reference.wav  # optional: voice cloning
```

### Implementation

- `workflow/tts/omnivoice.ts` — Gradio API adapter (`_design_fn` endpoint)
- `workflow/tts/index.ts` — registered as `omnivoice` provider in the switch

Follows the existing modular TTS architecture (`workflow/tts/*.ts`).